### PR TITLE
Keep formats order

### DIFF
--- a/python/brainvisa/configuration/qt4gui/databases_configuration_qt4gui.py
+++ b/python/brainvisa/configuration/qt4gui/databases_configuration_qt4gui.py
@@ -316,6 +316,10 @@ class FormatsSequence_Qt4GUI(QtGUI):
         self.btnDown.clicked.connect(self._down)
         hb.addWidget(self.btnDown)
 
+        self.btnDefault = Qt.QPushButton(_('Default'), editionWidget)
+        self.btnDefault.clicked.connect(self._default)
+        hb.addWidget(self.btnDefault)
+
         l.addLayout(hb)
 
         #hb = Qt.QHBoxLayout()
@@ -394,3 +398,7 @@ class FormatsSequence_Qt4GUI(QtGUI):
                 self.btnDown.setEnabled(1)
             else:
                 self.btnDown.setEnabled(0)
+
+    def _default(self, editionWidget):
+        object = FormatsSequence.all_formats()
+        self.updateEditionWidget(editionWidget, object)


### PR DESCRIPTION
This PR keep the formats order in case of formats order have been saved for the database. To keep the possibility to use the default order of *AimsGlobal*, a **Default** button is added to sort formats list in the default order defined in *AimsGlobal*.