### PR TITLE
Rename ExecutionNode.setHidden to avoid confusion

### DIFF
--- a/python/brainvisa/processes.py
+++ b/python/brainvisa/processes.py
@@ -2343,7 +2343,7 @@ class ExecutionNode(object):
             return ExecutionNodeGUI(parent, self._parameterized())
         return None
 
-    def setHidden(self, hidden):
+    def setNodeHidden(self, hidden=True):
         """
         Set the status of this node for graphical user interface.
         """


### PR DESCRIPTION
The new method ExecutionNode.setHidden shadows Parameterized.setHidden, which
was previously available on an ExecutionNode via __getattr__. Renaming the
method to ExecutionNode.setNodeHidden to avoid changing existing behaviour.

Fixes: https://github.com/brainvisa/axon/issues/15