### PR TITLE
add encoding for open in python3 in documentation generator

### DIFF
--- a/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py
+++ b/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py
@@ -109,7 +109,7 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
 <html>
 <head>
 <title>{process_info_name}</title>
-<meta http-equiv="Content-Type" content="text/html; charset={default_encoding}">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta content="BrainVISA {short_version}" name="generator">
 <link rel="stylesheet" href="../../axon.css" media="screen" />
 </head>
@@ -117,7 +117,6 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
 <h1><a href="bvshowprocess://{process_info_id}"><img src="../../images/icons/icon_process.png" border="0"></a>
 <a name="bv_process%{process_info_id}">{process_info_name}</a></h1>
         """.format(
-            default_encoding=sys.getdefaultencoding(),
             short_version=neuroConfig.shortVersion,
             process_info_id=processInfo.id,
             process_info_name=tr.translate(processInfo.name)
@@ -384,7 +383,7 @@ def generateHTMLProcessesDocumentation(context,
                 f.write(u"""
 <html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset={encoding}">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta content="BrainVISA {short_version}" name="generator">
   <link rel="stylesheet" href="{subdirs}axon.css" media="screen" />
 </head>
@@ -392,7 +391,6 @@ def generateHTMLProcessesDocumentation(context,
 {html_content}
 </body></html>
                                       """.format(
-                    encoding=sys.getdefaultencoding(),
                     short_version=neuroConfig.shortVersion,
                     subdirs='../' * nsubdirs,
                     html_content=XHTML.html(c)

--- a/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py
+++ b/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py
@@ -103,7 +103,10 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
         if not os.path.isdir(p):
             os.makedirs(p)
         # Main page
-        f = open(htmlFileName, 'w')
+        if int(sys.version[0]) < 3:
+            f = open(htmlFileName, 'w')
+        else:
+            f = open(htmlFileName, 'w', encoding='utf-8')
         print('<html>', file=f)
         print('<head>', file=f)
         print('<title>' + tr.translate(processInfo.name) + '</title>', file=f)

--- a/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py
+++ b/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py
@@ -105,7 +105,7 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
             os.makedirs(p)
         # Main page
         f = io.open(htmlFileName, 'w', encoding='utf-8')
-        f.write(six.text_type("""
+        f.write(u"""
 <html>
 <head>
 <title>{process_info_name}</title>
@@ -121,11 +121,7 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
             short_version=neuroConfig.shortVersion,
             process_info_id=processInfo.id,
             process_info_name=tr.translate(processInfo.name)
-        )))
-        # unicode strings written in this file are encoded using default encoding
-        # to choose a different encoding, unicode_string.encode("encoding") should be used
-        # in Brainvisa, the default encoding is set at initilization using
-        # sys.setdefaultencoding in neuro.py
+        ))
         short = d.get('short')
         if short:
             short = convertSpecialLinks(short, l, '', tr)
@@ -135,11 +131,11 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
             if short:
                 short = convertSpecialLinks(short, l, '', tr)
                 short = XHTML.html(short)
-        f.write(six.text_type("""
+        f.write(u"""
 <blockquote>
 {short}
 </blockquote>
-        """.format(short=short)))
+        """.format(short=short))
 
         # Description
         long = d.get('long')
@@ -152,14 +148,14 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
                 long = convertSpecialLinks(long, l, '', tr)
                 long = XHTML.html(long)
         if long:
-            f.write(six.text_type("""
+            f.write(u"""
 '<h2>{description}</h2><blockquote>'
 {long}
 '</blockquote>'
                     """.format(
                 description=tr.translate('Description'),
                 long=long
-            )))
+            ))
 
         try:
             signature = getProcessInstance(processInfo.id).signature
@@ -191,7 +187,7 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
         if signature:
             # Parameters
             p = d.get('parameters', {})
-            f.write(six.text_type('<h2>' + tr.translate('Parameters') + '</h2>'))
+            f.write(u'<h2>{}</h2>'.format(tr.translate('Parameters')))
             for i, j in signature:
                 ti = j.typeInfo(tr)
                 descr = p.get(i, '')
@@ -200,8 +196,8 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
                 if not descr and l != 'en':
                     descr = XHTML.html(pen.get(i, ''))
                 type_descr = param_type_descr(j)
-                f.write(six.text_type('<blockquote><b>' + i + '</b>: ' + type_descr))
-                f.write(six.text_type('<i> ( '))
+                f.write(u'<blockquote><b>{}</b>: {}'.format(i, type_descr))
+                f.write(u'<i> ( ')
                 if not j.mandatory:
                     f.write(six.text_type(_t_('optional, ')))
                 try:
@@ -214,8 +210,8 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
                     raise
                 except Exception as e:
                     print(e)
-                f.write(six.text_type(' )</i>'))
-                f.write(six.text_type("<blockquote>\n{}\n</blockquote></blockquote>".format(descr)))
+                f.write(u' )</i>')
+                f.write(u"<blockquote>\n{}\n</blockquote></blockquote>".format(descr))
 
                 try:
                     if len(ti) > 2:
@@ -230,7 +226,7 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
             processInfo.fileName, os.path.dirname(htmlFileName))
         processFileName = relative_path(
             processInfo.fileName, os.path.dirname(neuroConfig.mainPath))
-        f.write(six.text_type("""
+        f.write(u"""
 <h2>{technical_info}</h2><blockquote>
 <p><em>{toolbox} : </em>{toolbox_name}</p>
 <p><em>{user_level_label} : </em>{user_level}</p>
@@ -247,24 +243,24 @@ def generateHTMLDocumentation(processInfoOrId, translators, context, ontology):
             filename=tr.translate('File name'),
             process_file_ref=processFileRef,
             process_file_name=processFileName
-        )))
+        ))
 
         if supportedFormats:
-            f.write(six.text_type('<p><em>' + tr.translate('Supported file formats') + ' : </em>'))
+            f.write(u'<p><em>{} : </em>'.format(tr.translate('Supported file formats')))
             try:
                 for parameter, formats in supportedFormats:
                     f.write(
-                        six.text_type("<blockquote> {} :<blockquote> {} </blockquote></blockquote>".format(
+                        u"<blockquote> {} :<blockquote> {} </blockquote></blockquote>".format(
                             parameter, formats
-                        ))
+                        )
                     )
             except context.UserInterruption:
                 raise
             except Exception as e:
                 print(e)
-            f.write(six.text_type('</p>'))
-        f.write(six.text_type('</blockquote>\n'))
-        f.write(six.text_type('</body></html>'))
+            f.write(u'</p>')
+        f.write(u'</blockquote>\n')
+        f.write(u'</body></html>')
         f.close()
 
 # ----------------------------------------------------------------------------
@@ -385,7 +381,7 @@ def generateHTMLProcessesDocumentation(context,
                     os.makedirs(p)
                 nsubdirs = len(category.split('/')) + 3
                 f = io.open(os.path.join(p, 'category_documentation.html'), 'w', encoding='utf-8')
-                f.write(six.text_type("""
+                f.write(u"""
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset={encoding}">
@@ -400,7 +396,7 @@ def generateHTMLProcessesDocumentation(context,
                     short_version=neuroConfig.shortVersion,
                     subdirs='../' * nsubdirs,
                     html_content=XHTML.html(c)
-                )))
+                ))
                 f.close()
 
 # ----------------------------------------------------------------------------

--- a/python/brainvisa/configuration/neuroConfig.py
+++ b/python/brainvisa/configuration/neuroConfig.py
@@ -958,7 +958,10 @@ class Translator(object):
         translations = dict()
 
         for filePath in self.getTranslationFiles():
-            file = open(filePath, 'r')
+            if int(sys.version[0]) < 3:
+                file = open(filePath, 'r')
+            else:
+                file = open(filePath, 'r', encoding='utf-8')
             translations.update(readMinf(file)[0])
             file.close()
 

--- a/python/brainvisa/configuration/neuroConfig.py
+++ b/python/brainvisa/configuration/neuroConfig.py
@@ -216,6 +216,7 @@ from soma.minf.api import readMinf, writeMinf
 from soma.env import BrainvisaSystemEnv
 import brainvisa
 import six
+import io
 
 exitValue = 0
 
@@ -958,10 +959,7 @@ class Translator(object):
         translations = dict()
 
         for filePath in self.getTranslationFiles():
-            if int(sys.version[0]) < 3:
-                file = open(filePath, 'r')
-            else:
-                file = open(filePath, 'r', encoding='utf-8')
+            file = io.open(filePath, 'r', encoding='utf-8')
             translations.update(readMinf(file)[0])
             file.close()
 


### PR DESCRIPTION
The process `generateDocumentation` in the `Tools` toolbox doesn't seem to work in python3 for me.

The first error is : 
```
raceback (most recent call last):
  File "/casa/build/python/brainvisa/processes.py", line 3380, in _processExecution
    result = process.execution(self)
  File "/casa/build/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py", line 427, in execution
    write_category_html=self.write_category_html)
  File "/casa/build/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py", line 277, in generateHTMLProcessesDocumentation
    translators[l] = neuroConfig.Translator(l)
  File "/casa/build/python/brainvisa/configuration/neuroConfig.py", line 952, in __init__
    self.translations = self.getTranslations()
  File "/casa/build/python/brainvisa/configuration/neuroConfig.py", line 965, in getTranslations
    translations.update(readMinf(file)[0])
  File "/casa/build/python/soma/minf/api.py", line 299, in readMinf
    exceptions=exceptions))
  File "/casa/build/python/soma/minf/api.py", line 222, in iterateMinf
    start = source.read(5)
  File "/casa/build/python/soma/bufferandfile.py", line 119, in read
    result = self.__buffer + self.__file.read(size - buffer_size)
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 291: ordinal not in range(128)
```

To fix it, choosing 'utf-8' as `encoding` parameter when translation files are read fix it. 
Then another bug appears for nearly every file : 

```
Traceback (most recent call last):
  File "/casa/build/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py", line 287, in generateHTMLProcessesDocumentation
    generateHTMLDocumentation(pi, translators, context, ontology)
  File "/casa/build/brainvisa/toolboxes/tools/processes/documentation/generateDocumentation.py", line 189, in generateHTMLDocumentation
    print('<h2>' + tr.translate('Parameters') + '</h2>', file=f)
UnicodeEncodeError: 'ascii' codec can't encode character '\xe8' in position 9: ordinal not in range(128)
```

As before, adding `encoding` parameter when open html file fixes it. 
To keep compatibility with python 2, I added a check of the python version to only use the `encoding` parameter in python3.

During my search, I also found that between my BV python3 and BV python2, when I try `locale.getpreferredencoding()`, in python2 I get `UTF-8` and in python3 I get `ANSI_X3.4-1968`. 
I was wondering if it is better to change the encoding in the code (as I did), or if we can change something in the distro to change the preferred encoding value?