### PR TITLE
Default SPM configuration after local conf load

### DIFF
--- a/python/brainvisa/configuration/api.py
+++ b/python/brainvisa/configuration/api.py
@@ -146,6 +146,12 @@ def readConfiguration(mainPath, userProfile, homeBrainVISADir):
             showException(beforeError="Error while reading options from " + userOptionFile +
                           "<br>", afterError="<br>The option will be ignored.", exceptionInfo=exc)
 
+    # Apply SPM defaults from CONDA_PREFIX after loading user config
+    try:
+        configuration.SPM.apply_conda_defaults()
+    except Exception as e:
+        showException(beforeError="Error applying SPM conda defaults:<br>", exceptionInfo=e)
+
     equiv31_30 = {
         'R.executable': 'Rexecutable',
       'R.options': 'Roptions',

--- a/python/brainvisa/configuration/spm_configuration.py
+++ b/python/brainvisa/configuration/spm_configuration.py
@@ -36,6 +36,9 @@ class SPMConfiguration(ConfigurationGroup):
 
     def __init__(self, *args, **kwargs):
         super(SPMConfiguration, self).__init__(*args, **kwargs)
+
+    def apply_conda_defaults(self):
+        """Apply default SPM paths from CONDA_PREFIX if current values are empty."""
         conda_prefix = os.environ.get('CONDA_PREFIX')
         if conda_prefix:
             spm12_path = os.path.join(conda_prefix, 'spm12')


### PR DESCRIPTION
The SPM installed with pixi is configured by default in the brainvisa configuration.
I want to use a non-standalone SPM12 configuration (with matlab), and remove the standalonne configuration. After doing so and restarting Brainvisa, the configuration of the standalone SPM12 appeared again.

This was due to the filling of default standalone SPM12 configuration before local configuration reading, so it was not possible to check if non-standalonne configuration was already set locally.

I modified the SPM configuration in order to call a `apply_conda_defaults` method in order to be called after loading local configuration.

Now defaults values are set if no non-standalone config and no standalone config already in local configuration.